### PR TITLE
Update to latest Splat ECS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
-    "splat-ecs": "3.0.2"
+    "splat-ecs": "3.2.0"
   }
 }


### PR DESCRIPTION
Splatformer tutorial needed match-center system that was not present in v 3.0.2